### PR TITLE
inform about number of cards to be studied in each deck

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.1'
+        classpath 'com.android.tools.build:gradle:2.3.2'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/mobile/src/main/java/com/yannik/anki/WearMessageListenerService.java
+++ b/mobile/src/main/java/com/yannik/anki/WearMessageListenerService.java
@@ -163,6 +163,7 @@ public class WearMessageListenerService extends WearableListenerService {
 
                 try {
                     JSONObject deckOptions = new JSONObject(decksCursor.getString(decksCursor.getColumnIndex(FlashCardsContract.Deck.OPTIONS)));
+                    // These are the deck counts of the Deck. [learn, review, new]
                     JSONArray deckCounts = new JSONArray(decksCursor.getString(decksCursor.getColumnIndex(FlashCardsContract.Deck.DECK_COUNTS)));
                     Log.d(TAG, "deckCounts " + deckCounts);
                     Log.d(TAG, "deck Options " + deckOptions);

--- a/mobile/src/main/java/com/yannik/anki/WearMessageListenerService.java
+++ b/mobile/src/main/java/com/yannik/anki/WearMessageListenerService.java
@@ -48,6 +48,8 @@ import java.util.Map;
 import timber.log.Timber;
 
 import static com.yannik.anki.SettingsActivity.COM_ICHI2_ANKI_PERMISSION_READ_WRITE_DATABASE;
+import static com.yannik.sharedvalues.CommonIdentifiers.P2W_COLLECTION_LIST_DECK_COUNT;
+import static com.yannik.sharedvalues.CommonIdentifiers.P2W_COLLECTION_LIST_DECK_ID;
 
 
 /**
@@ -495,24 +497,34 @@ public class WearMessageListenerService extends WearableListenerService {
                 Log.d(TAG, "query for decks returned no result");
                 decksCursor.close();
             } else {
-                JSONObject decks = new JSONObject();
+                JSONObject decksJSONObj = new JSONObject();
                 do {
                     long deckID = decksCursor.getLong(decksCursor.getColumnIndex(FlashCardsContract.Deck.DECK_ID));
                     String deckName = decksCursor.getString(decksCursor.getColumnIndex(FlashCardsContract.Deck.DECK_NAME));
 
-
                     try {
                         JSONObject deckOptions = new JSONObject(decksCursor.getString(decksCursor.getColumnIndex(FlashCardsContract.Deck.OPTIONS)));
                         JSONArray deckCounts = new JSONArray(decksCursor.getString(decksCursor.getColumnIndex(FlashCardsContract.Deck.DECK_COUNTS)));
-                        Log.d(TAG, "deckCounts " + deckCounts);
-                        Log.d(TAG, "deck Options " + deckOptions);
-                        decks.put(deckName, deckID);
+
+                        Log.d(TAG, "deckName = " + deckName);
+                        Log.d(TAG, "deckCounts = " + deckCounts);
+                        Log.v(TAG, "deck Options = " + deckOptions);
+
+                        // Creating json object as we have numerous deck related information
+                        // Re-using flashcardscontract identifiers.
+                        JSONObject deckOJSONObj = new JSONObject();
+                        deckOJSONObj.put(P2W_COLLECTION_LIST_DECK_ID, deckID);
+                        deckOJSONObj.put(P2W_COLLECTION_LIST_DECK_COUNT, deckCounts);
+
+                        decksJSONObj.put(deckName, deckOJSONObj);
+
                     } catch (JSONException e) {
+                        Log.e(TAG, "Exception when generating JSON");
                         e.printStackTrace();
                     }
                 } while (decksCursor.moveToNext());
 
-                sendDecksToWear(decks);
+                sendDecksToWear(decksJSONObj);
             }
         }
         ;

--- a/sharedvalues/src/main/java/com/yannik/sharedvalues/CommonIdentifiers.java
+++ b/sharedvalues/src/main/java/com/yannik/sharedvalues/CommonIdentifiers.java
@@ -18,6 +18,11 @@ public class CommonIdentifiers {
 
     /** Message path for sending decks list. */
     public static final String P2W_COLLECTION_LIST = "/com.ichi2.wear/collections";
+    /** JSON key for deck id long. */
+    public static final String P2W_COLLECTION_LIST_DECK_ID = "deck_id";
+    /** JSON key for deck counts String. */
+    public static final String P2W_COLLECTION_LIST_DECK_COUNT = "deck_count";
+
     public static final String W2P_EXITING = "/com.ichi2.wear/exit";
 
 

--- a/sharedvalues/src/main/java/com/yannik/sharedvalues/CommonIdentifiers.java
+++ b/sharedvalues/src/main/java/com/yannik/sharedvalues/CommonIdentifiers.java
@@ -1,7 +1,7 @@
 package com.yannik.sharedvalues;
 
 /**
- * Created by Yannik on 29.04.2015.
+ * @author Created by Yannik on 29.04.2015.
  * Common string Identifiers used in the mobile and wear modules
  */
 public class CommonIdentifiers {
@@ -16,6 +16,7 @@ public class CommonIdentifiers {
 
     public static final String P2W_RESPOND_CARD = "/com.ichi2.wear/respondWithCard";
 
+    /** Message path for sending decks list. */
     public static final String P2W_COLLECTION_LIST = "/com.ichi2.wear/collections";
     public static final String W2P_EXITING = "/com.ichi2.wear/exit";
 

--- a/wear/src/main/java/com/yannik/anki/WearMainActivity.java
+++ b/wear/src/main/java/com/yannik/anki/WearMainActivity.java
@@ -205,7 +205,7 @@ public class WearMainActivity extends WearableActivity {
         });
 
         reviewFragment = ReviewFragment.newInstance(preferences, viewPager);
-        decksFragment = CollectionFragment.newInstance(null);
+        decksFragment = CollectionFragment.newInstance();
 
         if (preferences.isAmbientMode()) {
             setAmbientEnabled();

--- a/wear/src/main/res/layout/collection_list_item.xml
+++ b/wear/src/main/res/layout/collection_list_item.xml
@@ -1,12 +1,43 @@
 <?xml version="1.0" encoding="utf-8"?>
-<TextView xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@android:id/text1"
+
+<!-- One item in the collection list -->
+<!---->
+<!-- Resources and Ids for this page must start with "colllist__" -->
+
+
+<RelativeLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/colllist__mainLayout"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:textAppearance="?android:attr/textAppearanceListItemSmall"
-    android:gravity="center_vertical"
-    android:textColor="@color/dayTextColor"
+    android:orientation="horizontal"
     android:background="@drawable/round_rect_day"
-    android:paddingStart="?android:attr/listPreferredItemPaddingStart"
-    android:paddingEnd="?android:attr/listPreferredItemPaddingEnd"
-    android:minHeight="?android:attr/listPreferredItemHeightSmall" />
+    >
+    <TextView
+        android:id="@+id/colllist__textNumber"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textAppearance="?android:attr/textAppearanceListItemSmall"
+        android:gravity="center_vertical"
+        android:layout_alignParentEnd="true"
+        android:layout_centerVertical="true"
+        android:textColor="@color/dayTextColor"
+        android:paddingStart="?android:attr/listPreferredItemPaddingStart"
+        android:paddingEnd="?android:attr/listPreferredItemPaddingEnd"
+        android:minHeight="?android:attr/listPreferredItemHeightSmall"
+        tools:text="[1,2,3]"/>
+    <TextView
+        android:id="@+id/colllist__textcategory"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textAppearance="?android:attr/textAppearanceListItemSmall"
+        android:gravity="center_vertical"
+        android:textColor="@color/dayTextColor"
+        android:paddingStart="?android:attr/listPreferredItemPaddingStart"
+        android:paddingEnd="0dip"
+        android:minHeight="?android:attr/listPreferredItemHeightSmall"
+        android:layout_toStartOf="@id/colllist__textNumber"
+        tools:text="fake category with a very long name just to see"/>
+
+</RelativeLayout>

--- a/wear/src/main/res/layout/fragment_collection_list.xml
+++ b/wear/src/main/res/layout/fragment_collection_list.xml
@@ -16,7 +16,6 @@
         <ListView
             android:id="@android:id/list"
             android:layout_width="match_parent"
-
             android:layout_height="wrap_content"
             android:clipToPadding="false"
             android:overScrollMode="always"


### PR DESCRIPTION
Made change according to discussed issue #17 : 
Adding support for deck counts by modifying JSON format between mobile and wear apps .
Then deck list and adapter have been modified to have two textviews instead of one.
Finally deck counts have been summed to include sub-decks and colorized.
Result is looking like this : 
![device-2017-05-21-224420](https://cloud.githubusercontent.com/assets/3626228/26287436/c072f1ce-3e7b-11e7-8034-821298e75a02.png)
